### PR TITLE
Imagick install fix

### DIFF
--- a/php-fpm/map.jinja
+++ b/php-fpm/map.jinja
@@ -31,6 +31,7 @@
                 },
             },
             'pecl': {
+              'imagick': { 'version': False },
               'mongo': { 'version': False },
               'ssh2': { 'version': False },
               'zendopcache': { 'version': '7.0.3' },

--- a/php-fpm/pecl/imagick.sls
+++ b/php-fpm/pecl/imagick.sls
@@ -3,5 +3,10 @@
 include:
   - repos
 
-imagick:
-  pecl.installed
+pecl-install-imagick:
+  pecl.installed:
+    - name: imagick
+    - defaults: True
+{% if php_fpm.pecl.imagick.version %}
+    - version: {{ php_fpm.pecl.imagick.version }}
+{% endif %}


### PR DESCRIPTION
Imagick wasn't installing as the default install type is interactive.  Specifying 'defaults: True' forces it to non-interactive.  Also added in the ability to specify the version of imagick to be installed via pillar data.