### PR TITLE
Add skip_verify option with a default "False" variable in the jinja map.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Add optional skip_verify with a sensible default False set via php_fpm.pkg_skip_verify.
+
 ## Version 1.0.5
 
 * Remove reference to shared dir in a macro: creates conflict if >1 deployed locally

--- a/php-fpm/init.sls
+++ b/php-fpm/init.sls
@@ -23,7 +23,7 @@ php:
   pkg:
     - installed
     - name: {{php_fpm.pkg}}
-
+    - skip_verify: {{ php_fpm.pkg_skip_verify }}
 
 /var/run/php5-fpm:
   file:

--- a/php-fpm/map.jinja
+++ b/php-fpm/map.jinja
@@ -8,6 +8,7 @@
             'extensions':[],
             'zend_extensions':[],
             'pkg': 'dsd-php5',
+            'pkg_skip_verify': False, 
             'manage_pools': True,
             'pools': {
                 'www': {


### PR DESCRIPTION
Due to the packages not being signed, I have added this fix.

This shouldn't make existing behaviour any worse.
